### PR TITLE
Dev/arg kwarg split

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Features include
 * seamless automatic tab completion using a method's function signature
   * supports: `bool`, `int`, `float`, `str`, anything that inherits from `Enum`, and `@property`-decorated methods (getter and setters)
 * automatic help generation directly from a method's docstring
+* variable positional (`*args`) and keyword-only (`**kwds`) input
 
 Inpromptu also provides a [prompt_toolkit](https://python-prompt-toolkit.readthedocs.io/en/master/)-compatible completer so you can build more complicated prompts while getting all of inpromptu's introspection elements for free.
 
@@ -141,27 +142,27 @@ biscuits        flux_capacitor  fridge          kelp            the_one_ring
 ```
 
 ## FAQs
-### Why not just use the python shell?
-You could! Inpromptu is intented to be a bit more minimalistic and user-friendly.
-Inpromptu can be used as a minimalistic UI on its own.
+### Why not just use the Python shell?
+Inpromptu is intented to be a minimalistic UI on its own.
+Tab-completion and inferring of arguments by type (esp Enums) makes it easier to understand how to invoke the function that strictly by using the shell.
 
 ### Is there any way I can tease out the core elements to build my own interface?
 Yes. In fact, core elements of Inpromptu can be hooked directly into [Python Prompt Toolkit](https://python-prompt-toolkit.readthedocs.io/en/master/) to provide the same kind of object-based completions with richer prompt features.
 See the examples folder for some inspiration.
 
 ### What's not implemented?
-* functions that use `*args` and `**kwds` as input
 * The [@overload](https://docs.python.org/3/library/typing.html#typing.overload) operator.
 * functions wrapped in decorators: like `@cache`, `@cached_property` from functools
   * Note: some cases may work already.
 * Recording a series of commands.
 
 ### What's Going to be Implemented Next?
-* `*args` and `**kwds`
 * Explicit handling of functions wrapped in decorators.
 * Overloading completions for specified functions
 
+## Similar Projects
+* [Kickoff](https://python-kickoff.readthedocs.io/en/latest/#)
+
 ## About the Author
 Inpromptu was written by someone who used cmd.py one-too-many times.
-There had to be a better solution.
-And Inpromptu is one of many.
+

--- a/examples/test_drive.py
+++ b/examples/test_drive.py
@@ -50,11 +50,14 @@ class TestDrive:
         if gallons:
             self.gallons += gallons
 
-    def add_passengers(self, passenger_list: list, buckle_them: bool = True):
+    def add_passengers_from_list(self, passenger_list: list, buckle_them: bool = True):
         self.passengers = passenger_list
         for passenger in self.passengers:
             buckle_str = "" if buckle_them else "NOT "
             print(f"adding {passenger} and {buckle_str}buckling them.")
+
+    def add_passengers(self, *passengers: str):
+        self.add_passengers_from_list(passengers)
 
     def add_gear(self, gear: Gear):
         print(f"adding {gear}")

--- a/inpromptu/inpromptu_base.py
+++ b/inpromptu/inpromptu_base.py
@@ -7,6 +7,7 @@ from abc import ABC, abstractmethod
 from ast import literal_eval
 from enum import Enum
 from inspect import signature
+from inspect import _ParameterKind as ParamKind
 from .object_method_manager import ObjectMethodManager
 from .errors import UserInputError
 
@@ -143,6 +144,60 @@ class InpromptuBase(ABC):
             f"'{val_str}' could not be evaluated as any of the following "
             f"types: {param_types}.")
 
+    def get_remaining_params(self, func, arg_blocks, skip_self_or_cls = True):
+        """For a given function and given list of arguments, return the
+        remaining parameters.
+
+        Raise SyntaxError if input params are invalid.
+        """
+        positional_params = [ParamKind.POSITIONAL_ONLY, ParamKind.POSITIONAL_OR_KEYWORD]
+        keyword_params = [ParamKind.POSITIONAL_OR_KEYWORD, ParamKind.KEYWORD_ONLY]
+        sig = signature(func)
+        remaining_params = list(sig.parameters.values())
+
+        if skip_self_or_cls and remaining_params \
+            and remaining_params[0].name in ['self', 'cls']:
+            remaining_params.pop(0)
+        # Handle bail-early case.
+        if not len(remaining_params) and not arg_blocks:
+            return []
+        # Handle remaining cases.
+        # Match param to input (arg or kwarg).
+        parsing_kwargs = False  # Used to enforce args before kwargs
+        for index, arg_block in enumerate(arg_blocks):
+            sub_block, finished = container_split(arg_block, '=')
+            last_block = (index == (len(arg_blocks) - 1))
+            #input_is_arg = len(sub_block) == 1
+            input_is_kwarg = len(sub_block) == 2
+            parsing_kwargs = input_is_kwarg or parsing_kwargs
+            next_param = remaining_params[0]
+            try:
+                # arg cases
+                if not parsing_kwargs:
+                    if next_param.kind in positional_params:
+                        remaining_params.pop(0)
+                        continue
+                    if next_param.kind == ParamKind.VAR_POSITIONAL:
+                        continue
+                # kwarg cases.
+                # Remove any *args present as soon as we start seeing kwargs.
+                if parsing_kwargs and next_param.kind == ParamKind.VAR_POSITIONAL:
+                    remaining_params.pop(0)
+                    next_param = remaining_params[0]
+                # Ensure final kwarg was fully entered. i.e: something after '='
+                if last_block and (not finished or (sub_block[1] == "")):
+                    continue
+                if next_param.kind in keyword_params:
+                    remaining_params.pop(0)
+                    continue
+                if next_param.kind == ParamKind.VAR_KEYWORD:
+                    continue
+                raise SyntaxError(f"Invalid parameter input: '{arg_block}' "
+                                  f"for parameter: {next_param.name}.")
+            except IndexError:
+                raise SyntaxError(f"Too many input arguments for the function: {func}.")
+        return remaining_params
+
     def parse_args_from_input(self, line, sep=" "):
         """Parse line into args and kwargs with a custom delimiter.
         Raise syntax error if the line is not parsable.
@@ -182,7 +237,7 @@ class InpromptuBase(ABC):
                     fn_name = line.split()[0]
                     args_and_kwargs = ""
                 args, kwargs, completed = self.parse_args_from_input(args_and_kwargs)
-                self.log.warning(f"parsed args: {args}, kwargs: {kwargs}")
+                self.log.info(f"parsed args: {args}, kwargs: {kwargs}")
                 # Extract function.
                 # Property getter shortcut.
                 if not args and not kwargs and fn_name in self.omm.property_getters:

--- a/inpromptu/inpromptu_prompt_toolkit.py
+++ b/inpromptu/inpromptu_prompt_toolkit.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 """Prompt-toolkit implementation of Inpromptu."""
 
+from inspect import _ParameterKind as ParamKind
 from prompt_toolkit import prompt, PromptSession
 from prompt_toolkit.shortcuts import CompleteStyle
 from prompt_toolkit.completion import Completer, Completion
+from prompt_toolkit import print_formatted_text as print
 from .inpromptu_base import InpromptuBase
 from .inpromptu_base import container_split
 
@@ -68,15 +70,14 @@ class Inpromptu(InpromptuBase):
             self.func_params = [p.name for p in param_objects]
 
             # Now generate completion list for params not yet entered.
-            for param_name in self.func_params:
-                completion = f"{param_name}="
+            for param in param_objects:
+                completion = f"{param.name}="
                 # No space case: <kwarg_name>=<value> is partially typed or fully typed but missing a space.
-                if line[-1] != self.__class__.DELIM and \
-                    param_entries[-1].startswith(completion):
+                if line[-1] != self.__class__.DELIM and param_entries[-1].startswith(completion):
                     partial_val_text = param_entries[-1].split('=')[-1]
                     func_param_completions = \
                         self._get_param_options(self.func_name,
-                                                param_name,
+                                                param.name,
                                                 partial_val_text)
                     completions = [completion+v for v in func_param_completions]
                     display = {completion+v:v for v in func_param_completions}
@@ -94,12 +95,20 @@ class Inpromptu(InpromptuBase):
                 # regular check
                 if completion.startswith(word) and not skip:
                     completions.append(completion)
-                    arg_types = self.omm.method_defs[self.func_name]['parameters'][param_name]['types']
+                    arg_types = self.omm.method_defs[self.func_name]['parameters'][param.name]['types']
                     arg_types_str = "|".join([a.__name__ for a in arg_types])
                     display[completion] = completion + f"<{arg_types_str}>"
+                # Exit early: provide required args one-at-a-time so we complete
+                # them in order.
+                if param.default == param.empty:
+                    break
 
         # Finally, yield any completions.
         for completion in completions:
+            # Note: it's possible to inject custom print statements here.
+            # TODO: we could display the whole function signature and cross off already-entered arguments.
+            # FIXME: if args are required (i.e: no default), do not display
+            #   kwargs that follow as completion options.
             yield Completion(completion,
                              start_position=-len(word),
                              display=display.get(completion, completion),

--- a/inpromptu/inpromptu_prompt_toolkit.py
+++ b/inpromptu/inpromptu_prompt_toolkit.py
@@ -54,42 +54,18 @@ class Inpromptu(InpromptuBase):
         # Complete the fn params (i.e: args in order then kwargs by name)
         else:
             self.func_name = cmd_with_args[0]
+            param_entries = cmd_with_args[1:]
             # Check to make sure func name has parameters and was typed correctly.
             if self.func_name not in self.omm.method_defs:
                 return None
-            self.func_params = self.omm.method_defs[self.func_name]['param_order']
-            if self.func_params[0] in ['self', 'cls']:
-                self.func_params = self.func_params[1:]
 
-            # First filter out already-entered positional arguments.
-            # Abort upon finding first keyword argument.
-            first_kwarg_found = False
-            first_kwarg_index = 0
-            param_entries = cmd_with_args[1:]
-            for entry_index, param_entry in enumerate(param_entries):
-                kwarg = None
-                # Check if text entry is a fully-entered kwarg.
-                for param_name in self.func_params:
-                    # kwargs are indentified by the string: "kwarg_name=kwarg_val"
-                    completion = f"{param_name}="
-                    #print(f"param_entry: {param_entry} | completion: {complection}")
-                    if param_entry.startswith(completion):
-                        kwarg = param_name
-                        if not first_kwarg_found:
-                            first_kwarg_found = True
-                            first_kwarg_index = entry_index
-                        break
-                if first_kwarg_found:
-                    break
-                # Don't remove the last element if it is not fully entered.
-                if param_entry == param_entries[-1] and line[-1] != self.__class__.DELIM:
-                    break
-                first_kwarg_index += 1
-
-            self.func_params = self.func_params[first_kwarg_index:]
-
-            #print(f"found kwarg: {first_kwarg_found} | at index: {first kwarg_index}")
-            #print(f"unfiltered params: {self.func_params}")
+            # Get function params that have not been entered
+            func = self.omm.methods[self.func_name]
+            # Don't search the last element if it's not fully entered.
+            param_entries_to_search = param_entries[:-1] \
+                if (line[-1] != self.__class__.DELIM) else param_entries
+            param_objects = self.get_remaining_params(func, param_entries_to_search)
+            self.func_params = [p.name for p in param_objects]
 
             # Now generate completion list for params not yet entered.
             for param_name in self.func_params:

--- a/inpromptu/inpromptu_readline.py
+++ b/inpromptu/inpromptu_readline.py
@@ -161,7 +161,6 @@ class Inpromptu(InpromptuBase):
         # Complete the fn params.
         self.func_name = cmd_with_args[0]
         param_entries = cmd_with_args[1:]
-
         # Check to make sure func name has parameters and was typed correctly.
         if self.func_name not in self.omm.method_defs:
             return None

--- a/inpromptu/inpromptu_readline.py
+++ b/inpromptu/inpromptu_readline.py
@@ -165,39 +165,6 @@ class Inpromptu(InpromptuBase):
         # Check to make sure func name has parameters and was typed correctly.
         if self.func_name not in self.omm.method_defs:
             return None
-        ## remaining params to complete stored in self.func_params.
-        #self.func_params = self.omm.method_defs[self.func_name]['param_order']
-        #if self.func_params[0] in {'self', 'cls'}:
-        #    self.func_params = self.func_params[1:]
-        #
-        ## First filter out already-entered positional arguments.
-        ## Abort upon first keyword.
-        #first_kwarg_found = False
-        #first_kwarg_index = 0
-        #param_entries = cmd_with_args[1:] # everything typed after the fn name.
-        #for entry_index, text_block in enumerate(param_entries):
-        #    kwarg = None
-        #    # Check if text entry is a fully-entered kwarg.
-        #    for param_order_index, param_name in enumerate(self.func_params):
-        #        completion = f"{param_name}="
-        #        #print(f"text block: {text_block} | completion {completion}")
-        #        if text_block.startswith(completion):
-        #            kwarg = param_name
-        #            if not first_kwarg_found:
-        #                first_kwarg_found = True
-        #                first_kwarg_index = entry_index
-        #            break
-        #    if first_kwarg_found:
-        #        break
-        #    # Don't remove the last element if it is not fully entered.
-        #    if text_block == param_entries[-1] and line[-1] is not self.__class__.DELIM:
-        #        break
-        #    first_kwarg_index += 1
-        #self.func_params = self.func_params[first_kwarg_index:]
-
-        ##print(f"found kwarg: {first_kwarg_found} | at index {first_kwarg_index}")
-        ##print(f"unfiltered params: {self.func_params}")
-
 
         # Get function params that have not been entered.
         func = self.omm.methods[self.func_name]

--- a/tests/container_split_tests.py
+++ b/tests/container_split_tests.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env/python3
+import pytest
+from inpromptu.inpromptu_base import container_split
+
+
+def test_basic_split():
+
+    basic_input = "hello there buddy"
+    result = container_split(basic_input)
+    assert result[0] == basic_input.split() and result[1] == True
+
+
+def test_basic_custom_delimiter():
+
+    basic_input = "hello|there|buddy"
+    result = container_split(basic_input, sep='|')
+    assert result[0] == basic_input.split(sep='|') and result[1] == True
+
+def test_split_w_nested_string():
+
+    basic_input = "arg0   arg1 arg2='fred, phyllis, and phillip'"
+    result = container_split(basic_input)
+    assert result[0] == ["arg0", "arg1", "arg2='fred, phyllis, and phillip'"] \
+        and result[1] == True
+
+def test_comma_split_w_nested_string():
+
+    basic_input = "arg0, arg1, arg2='fred, phyllis, and phillip'"
+    result = container_split(basic_input, sep=',')
+    assert result[0] == ["arg0", " arg1", " arg2='fred, phyllis, and phillip'"] \
+        and result[1] == True
+
+def test_equals_split_w_equals_in_string():
+
+    basic_input = "arg0='bob=0'"
+    result = container_split(basic_input, sep='=')
+    assert result[1] == True
+    assert result[0] == ["arg0", "'bob=0'"]
+
+def test_open_container():
+
+    basic_input = "arg0=0 arg1=(1,"
+    result = container_split(basic_input)
+    print(result[0])

--- a/tests/container_split_tests.py
+++ b/tests/container_split_tests.py
@@ -11,34 +11,36 @@ def test_basic_split():
 
 
 def test_basic_custom_delimiter():
-
     basic_input = "hello|there|buddy"
     result = container_split(basic_input, sep='|')
     assert result[0] == basic_input.split(sep='|') and result[1] == True
 
 def test_split_w_nested_string():
-
     basic_input = "arg0   arg1 arg2='fred, phyllis, and phillip'"
     result = container_split(basic_input)
     assert result[0] == ["arg0", "arg1", "arg2='fred, phyllis, and phillip'"] \
         and result[1] == True
 
 def test_comma_split_w_nested_string():
-
     basic_input = "arg0, arg1, arg2='fred, phyllis, and phillip'"
     result = container_split(basic_input, sep=',')
     assert result[0] == ["arg0", " arg1", " arg2='fred, phyllis, and phillip'"] \
         and result[1] == True
 
 def test_equals_split_w_equals_in_string():
-
     basic_input = "arg0='bob=0'"
     result = container_split(basic_input, sep='=')
     assert result[1] == True
     assert result[0] == ["arg0", "'bob=0'"]
 
 def test_open_container():
+    basic_input = "arg0=(1,"
+    result = container_split(basic_input, '=')
+    assert result[1] == False
+    assert result[0] == ["arg0", "(1,"]
 
-    basic_input = "arg0=0 arg1=(1,"
-    result = container_split(basic_input)
-    print(result[0])
+def test_open_container2():
+    basic_input = "arg0="
+    result = container_split(basic_input, '=')
+    assert result[1] == True # Technically, this behavior is equivalent to split
+    assert result[0] == ["arg0", ""]


### PR DESCRIPTION
*args and **kwargs now supported.

Completion for these kinds of arguments is yet to be done, but they can be parsed and converted to the correct types if passed into the REPL as input.